### PR TITLE
Change the pre-commit-hook message

### DIFF
--- a/detect_secrets/pre_commit_hook.py
+++ b/detect_secrets/pre_commit_hook.py
@@ -210,11 +210,12 @@ def _print_mitigation_suggestions():
         'in #security',
     )
     suggestions = [
-        'For information about putting your secrets in a safer place, ' +
-        'please ask ' + security_team,
-        'Mark false positives with an inline ' +
-        '`pragma: allowlist secret` comment',
-        'Commit with `--no-verify` if this is a one-time false positive',
+        'Scan again your repository.',
+        'Audit the potential secrets stored in the' +
+        ' baseline and correct the true positives.' +
+        'If any secret had already been commited you' +
+        ' must remove and change it.',
+        'Try the commit again.'
     ]
 
     wrapper = textwrap.TextWrapper(

--- a/detect_secrets/pre_commit_hook.py
+++ b/detect_secrets/pre_commit_hook.py
@@ -213,8 +213,9 @@ def _print_mitigation_suggestions():
         'Scan again your repository.',
         'Audit the potential secrets stored in the' +
         ' baseline and correct the true positives.' +
-        'If any secret had already been commited you' +
+        ' If any secret had already been committed you' +
         ' must remove and change it.',
+        'Stage the baseline for the commit.',
         'Try the commit again.'
     ]
 


### PR DESCRIPTION
Cambio en el mensaje que devuelve el pre-commit hook cuando se detecta algún secreto potencial en el repositorio que no ha sido previamente marcado como falso positivo.

@pablosantiagolopez te pongo como revisor, comenta si ves algo que mejorar y lo ponemos en común.

Nota: iré creando nuevos PRs para la configuración de los hooks, basado en la PoC de mi fork https://github.com/syn-4ck/detect-secrets