### PR TITLE
Add docker image & configure pre-commit hook via docker

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,8 +1,8 @@
--   id: detect-secrets
+-   id: detect-secrets-docker
     name: Detect secrets
     description: Detects high entropy strings that are likely to be passwords.
     entry: detect-secrets-hook
     args: ['--base64-limit', '4.5', '--hex-limit', '3']
-    language: python
+    language: docker
     # for backward compatibility
     files: .*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:18.04
+
+LABEL version="v0.14.4"
+LABEL description="detect-secrets is an aptly named module for (surprise, surprise) detecting secrets within a code base."
+
+RUN apt update
+RUN apt-get install -y python3 python3-pip
+
+ADD . /detect-secrets
+WORKDIR /detect-secrets
+
+RUN python3 setup.py build
+RUN python3 setup.py install


### PR DESCRIPTION
Creada primera versión de la imagen Docker a través de Dockerfile. Se crea usando de base ubuntu v18.04 y se instala en la misma detect-secrets de forma manual. 

Esta imagen se crea para ser utilizada en la prueba del hook, de tal modo que se pueda usar la imagen docker no tan solo para escaneos en local si no para ser integrada en el precommit hook, sin necesidad de tener detect-secrets instalado en local.

![evidencia](https://user-images.githubusercontent.com/43778014/104914976-3c7e3980-5990-11eb-88dc-0a56ec8da897.PNG)

Esto ha sido probado anteriormente en mi fork: https://github.com/syn-4ck/detect-secrets

@pablosantiagolopez te pongo de reviewer, ofrece todo el feedback que desees y lo vemos.

Un saludo.
