### PR TITLE
Add true positives warning message for hook and fix messages

### DIFF
--- a/detect_secrets/core/baseline.py
+++ b/detect_secrets/core/baseline.py
@@ -137,13 +137,8 @@ def baseline_has_true_secrets (baseline):
     :rtype: Boolean
     :returns: Boolean that returns True if exists some true secret in the baseline 
     """
-    exclude_files_regex = None
-    if baseline.exclude_files:
-        exclude_files_regex = re.compile(baseline.exclude_files, re.IGNORECASE)
 
     for filename in baseline.data:
-        if exclude_files_regex and exclude_files_regex.search(filename):
-            continue
 
         for secret in baseline.data[filename]:
             if baseline.data[filename].get(secret).is_secret is True:

--- a/detect_secrets/core/baseline.py
+++ b/detect_secrets/core/baseline.py
@@ -128,6 +128,29 @@ def get_secrets_not_in_baseline(results, baseline):
 
     return new_secrets
 
+def baseline_has_true_secrets (baseline):
+    """
+    :type baseline: SecretsCollection
+    :param baseline: SecretsCollection of baseline results.
+                     This will be updated accordingly (by reference)
+
+    :rtype: Boolean
+    :returns: Boolean that returns True if exists some true secret in the baseline 
+    """
+    exclude_files_regex = None
+    if baseline.exclude_files:
+        exclude_files_regex = re.compile(baseline.exclude_files, re.IGNORECASE)
+
+    for filename in baseline.data:
+        if exclude_files_regex and exclude_files_regex.search(filename):
+            continue
+
+        for secret in baseline.data[filename]:
+            if baseline.data[filename].get(secret).is_secret is True:
+                return True
+
+    return False
+
 
 def trim_baseline_of_removed_secrets(results, baseline, filelist):
     """


### PR DESCRIPTION
Abro esta pull request para incorporar un nuevo mensaje de aviso (WARNING) en caso de que el hook detecte secretos marcados como secretos reales en el baseline. 
El hook solo debe fallar si incorporas contenido nuevo con secretos, pero ignora el ya comiteado. De este modo se advierte al usuario que sigue teniendo secretos en código y que debe verificarlos igualmente.

![evidencia](https://user-images.githubusercontent.com/43778014/106024036-a486fb00-60c7-11eb-98e2-be8e8b39e176.PNG)


@pablosantiagolopez lo revisas cuando puedas y me comentas?

Gracias. Un saludo.